### PR TITLE
(#2) Prevent panic when arguments don't match format string

### DIFF
--- a/issue/printf.go
+++ b/issue/printf.go
@@ -41,12 +41,14 @@ func MapFprintf(writer io.Writer, formatString string, args H) {
 	posFormatString, argCount, expectedArgs := extractNamesAndLocations(formatString)
 	posArgs := make([]interface{}, argCount)
 	for k, v := range expectedArgs {
+		var a interface{}
 		if arg, ok := args[k]; ok {
-			for _, pos := range v {
-				posArgs[pos] = arg
-			}
+			a = arg
 		} else {
-			panic(fmt.Sprintf(`missing argument matching key {%s} in format string %s`, k, formatString))
+			a = fmt.Sprintf(`%%!{%s}(MISSING)`, k)
+		}
+		for _, pos := range v {
+			posArgs[pos] = a
 		}
 	}
 	fmt.Fprintf(writer, posFormatString, posArgs...)

--- a/issue/printf_test.go
+++ b/issue/printf_test.go
@@ -1,9 +1,9 @@
 package issue
 
 import (
-	"testing"
-	"os"
 	"fmt"
+	"os"
+	"testing"
 )
 
 func assertEqual(t *testing.T, e, a interface{}) {
@@ -39,5 +39,5 @@ func ExampleMapFprintf_missingKey() {
 		}
 	}()
 	MapFprintf(os.Stdout, "%{foo} %{fee} %{fum}", H{"foo": "hello", "fum": "world"})
-	// Output: missing argument matching key {fee} in format string %{foo} %{fee} %{fum}
+	// Output: hello %!{fee}(MISSING) world
 }


### PR DESCRIPTION
This commit ensures that a printout is produced even if arguments are
missing when using issue.MapFprintf()