### PR TITLE
Add ability to include stacktrace in issue.Reported

### DIFF
--- a/issue/reported.go
+++ b/issue/reported.go
@@ -2,6 +2,8 @@ package issue
 
 import (
 	"bytes"
+	"runtime"
+	"strconv"
 )
 
 // A Reported instance contains information of an issue such as an
@@ -43,10 +45,67 @@ type reported struct {
 	severity  Severity
 	args      H
 	location  Location
+	stack     []runtime.Frame
 }
 
-func NewReported(code Code, severity Severity, args H, location Location) Reported {
-	return &reported{code, severity, args, location}
+var includeStacktrace = false
+
+// IncludeStacktrace can be set to true to get all Reported to include a stacktrace.
+func IncludeStacktrace(flag bool) {
+	includeStacktrace = flag
+}
+
+func NewReported(code Code, severity Severity, args H, locOrSkip interface{}) Reported {
+	var location Location
+	skip := 2 // Default is to skip runtime.Callers and this function only
+	switch locOrSkip := locOrSkip.(type) {
+	case int:
+		skip = locOrSkip
+	case Location:
+		location = locOrSkip
+	}
+
+	r := &reported{code, severity, args, location, nil}
+	if includeStacktrace {
+		// Ask runtime.Callers for up to 100 pcs, including runtime.Callers itself.
+		pc := make([]uintptr, 100)
+		n := runtime.Callers(skip, pc)
+		if n > 0 {
+			pc = pc[:n] // pass only valid pcs to runtime.CallersFrames
+			frames := runtime.CallersFrames(pc)
+			stack := make([]runtime.Frame, 0, n)
+
+			// Loop to get frames.
+			// A fixed number of pcs can expand to an indefinite number of Frames.
+			for {
+				if frame, more := frames.Next(); more {
+					stack = append(stack, frame)
+				} else {
+					break
+				}
+			}
+			r.stack = stack
+		}
+	}
+
+	if r.location == nil {
+		if r.stack == nil {
+			for {
+				// Use first caller we can find with regards to given skip and use it
+				// as the location
+				skip--
+				if _, f, l, ok := runtime.Caller(skip); ok {
+					r.location = NewLocation(f, l, 0)
+					break
+				}
+			}
+		} else {
+			// Set location to first stack entry
+			tf := r.stack[0]
+			r.location = NewLocation(tf.File, tf.Line, 0)
+		}
+	}
+	return r
 }
 
 func (ri *reported) Argument(key string) interface{} {
@@ -60,7 +119,7 @@ func (ri *reported) OffsetByLocation(location Location) Reported {
 	} else {
 		loc = NewLocation(location.File(), location.Line()+loc.Line(), location.Pos())
 	}
-	return &reported{ri.issueCode, ri.severity, ri.args, loc}
+	return &reported{ri.issueCode, ri.severity, ri.args, loc, ri.stack}
 }
 
 func (ri *reported) Error() (str string) {
@@ -71,7 +130,19 @@ func (ri *reported) Error() (str string) {
 
 func (ri *reported) ErrorTo(b *bytes.Buffer) {
 	IssueForCode(ri.issueCode).Format(b, ri.args)
-	if ri.location != nil {
+	if ri.stack != nil {
+		for _, f := range ri.stack {
+			b.WriteString("\n at ")
+			b.WriteString(f.File)
+			b.WriteByte(':')
+			b.WriteString(strconv.Itoa(f.Line))
+			if f.Function != `` {
+				b.WriteString(" (")
+				b.WriteString(f.Function)
+				b.WriteByte(')')
+			}
+		}
+	} else if ri.location != nil {
 		b.WriteByte(' ')
 		appendLocation(b, ri.location)
 	}


### PR DESCRIPTION
This commit adds the function issue.IncludeStacktrace(bool). When called
with true, subsequently created Reported instance will include a
stactrace.